### PR TITLE
Interview changes: referring to products inside a customer feedback review

### DIFF
--- a/src/main/kotlin/com/connectly/messengerreviewbot/database/models/CustomerFeedbackReview.kt
+++ b/src/main/kotlin/com/connectly/messengerreviewbot/database/models/CustomerFeedbackReview.kt
@@ -15,9 +15,10 @@ data class CustomerFeedbackReview(
     @ManyToOne(optional = false)
     @JoinColumn(name = "business_page_id")
     var businessPage: BusinessPage,
-
+    
     var reviewText: String?,
-    var starRating: Int
+    var starRating: Int,
+    var productName: String?
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/com/connectly/messengerreviewbot/services/CustomerFeedbackReviewService.kt
+++ b/src/main/kotlin/com/connectly/messengerreviewbot/services/CustomerFeedbackReviewService.kt
@@ -14,7 +14,8 @@ class CustomerFeedbackReviewService(
     fun createCustomerFeedbackReview(
         businessPage: BusinessPage,
         reviewText: String?,
-        starRating: Int
+        starRating: Int,
+        productName: String?
     ): CustomerFeedbackReview {
         return customerFeedbackReviewRepository.save(
             CustomerFeedbackReview(
@@ -22,7 +23,8 @@ class CustomerFeedbackReviewService(
                 externalId = idGenerator.generateId(),
                 businessPage = businessPage,
                 reviewText = reviewText,
-                starRating = starRating
+                starRating = starRating,
+                productName = productName
             )
         )
     }

--- a/src/main/kotlin/com/connectly/messengerreviewbot/services/MessengerPlatformMessagingService.kt
+++ b/src/main/kotlin/com/connectly/messengerreviewbot/services/MessengerPlatformMessagingService.kt
@@ -3,6 +3,7 @@ package com.connectly.messengerreviewbot.services
 import com.connectly.messengerreviewbot.database.models.BusinessPage
 import com.connectly.messengerreviewbot.services.models.*
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
@@ -143,6 +144,25 @@ class MessengerPlatformMessagingService(
             throw Exception("Error connecting to Send API")
         } catch (e: HttpClientErrorException) {
             throw Exception("Cannot create message due to invalid inputs")
+        }
+    }
+
+    fun getProducts(): List<MockProduct> {
+        val headers = HttpHeaders()
+        headers.contentType = MediaType.APPLICATION_JSON
+
+        val requestEntity = HttpEntity(null, headers)
+        return try {
+            restTemplate.exchange(
+                "https://62daf70dd1d97b9e0c49ca5d.mockapi.io/v1/products",
+                HttpMethod.GET,
+                requestEntity,
+                object : ParameterizedTypeReference<List<MockProduct>>() {}
+            ).body ?: throw Exception("Cannot get products due to an unknown error")
+        } catch (e: ResourceAccessException) {
+            throw Exception("Error connecting to Mock API")
+        } catch (e: HttpClientErrorException) {
+            throw Exception("Cannot get products due to invalid inputs")
         }
     }
 

--- a/src/main/kotlin/com/connectly/messengerreviewbot/services/models/MockProduct.kt
+++ b/src/main/kotlin/com/connectly/messengerreviewbot/services/models/MockProduct.kt
@@ -1,0 +1,6 @@
+package com.connectly.messengerreviewbot.services.models
+
+data class MockProduct(
+    val id: Int,
+    val productName: String
+)

--- a/src/main/resources/db/migration/V1.2__add_product_name_to_customer_review.sql
+++ b/src/main/resources/db/migration/V1.2__add_product_name_to_customer_review.sql
@@ -1,0 +1,3 @@
+ALTER TABLE customer_feedback_review
+ADD COLUMN product_name VARCHAR(128);
+


### PR DESCRIPTION
Able to successfully associate productNames with a review. Here are screenshots of product names being mentioned in review text, and the corresponding table entry: 

Review text: 
<img width="672" alt="Screen Shot 2023-09-01 at 12 11 40 PM" src="https://github.com/layeleomehta/connectly-messenger-review-bot/assets/32559821/e11e3bfb-d153-4485-819e-6ef3a656f2f7">

CustomerFeedbackReview table entry: 
<img width="1048" alt="Screen Shot 2023-09-01 at 12 12 27 PM" src="https://github.com/layeleomehta/connectly-messenger-review-bot/assets/32559821/12f5bf75-d016-4fc3-a3dc-1a68a5fe8606">

**Note**: this parsing logic only works for product names that have one word in the name. 